### PR TITLE
Fixed bug that spawned new instances after each deploy

### DIFF
--- a/meteoric.sh
+++ b/meteoric.sh
@@ -110,7 +110,7 @@ fi;
 
 DEPLOY="$DEPLOY
 echo Starting forever;
-sudo -E forever start bundle/main.js;
+sudo -E forever restart bundle/main.js || forever start bundle/main.js;
 "
 
 case "$1" in


### PR DESCRIPTION
With the forever start, a new node process is spawned each time and this can be painful as the listening port may be already in use.
With the restart || start, the bunlde will just restart when one is launched, or start on the first deploy
