### PR TITLE
cd "$INSTALL_DIR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deploy Meteor on EC2 (or your own server)
 The easiest way to install (or update) `meteoric` is using curl:
 
 ```bash
-$ curl https://raw.github.com/julien-c/meteoric.sh/master/install | sh
+$ curl https://raw.github.com/dnprock/meteoric.sh/master/install | sh
 ```
 
 You may need to `sudo` in order for the script to symlink `meteoric` to your `/usr/local/bin`.

--- a/install
+++ b/install
@@ -4,7 +4,7 @@ INSTALL_DIR="$HOME/.meteoric.sh"
 
 if [ ! -d "$INSTALL_DIR" ];
 then
-	git clone http://github.com/julien-c/meteoric.sh.git "$INSTALL_DIR"
+	git clone http://github.com/dnprock/meteoric.sh.git "$INSTALL_DIR"
 else
         cd "$INSTALL_DIR"
 	git pull "$INSTALL_DIR"

--- a/install
+++ b/install
@@ -6,7 +6,9 @@ if [ ! -d "$INSTALL_DIR" ];
 then
 	git clone http://github.com/julien-c/meteoric.sh.git "$INSTALL_DIR"
 else
+        cd "$INSTALL_DIR"
 	git pull "$INSTALL_DIR"
+	cd -
 fi
 
 if [ ! -f /usr/local/bin/meteoric ];


### PR DESCRIPTION
Only pull in cd "$INSTALL_DIR" and cd -

The rest is not needed, but maybe this fixes a bug where you are in the wrong directory initially from the install dir.
